### PR TITLE
feature "export to Cirq"

### DIFF
--- a/example/nodejs/various_gates.js
+++ b/example/nodejs/various_gates.js
@@ -1,0 +1,39 @@
+var QuantumCircuit = require("../../lib/quantum-circuit.js");
+
+var circuit = new QuantumCircuit();
+
+circuit.addGate("id", -1, 0);
+circuit.addGate("x", -1, 0);
+circuit.addGate("y", -1, 0);
+circuit.addGate("z", -1, 0);
+circuit.addGate("h", -1, 0);
+circuit.addGate("srn", -1, 0);
+circuit.addGate("r2", -1, 0);
+circuit.addGate("r4", -1, 0);
+circuit.addGate("r8", -1, 0);
+circuit.addGate("rx", -1, 0, {params: {theta: "pi/2"}});
+circuit.addGate("ry", -1, 0, {params: {theta: "pi/2"}});
+circuit.addGate("rz", -1, 0, {params: {phi: "pi/2"}});
+circuit.addGate("u1", -1, 0, {params: {lambda: "pi/2"}});
+circuit.addGate("u2", -1, 0, {params: {phi: "pi/2", lambda: "pi/4"}});
+circuit.addGate("u3", -1, 0, {params: {theta: "pi/2", phi: "pi/4", lambda: "pi/8"}});
+circuit.addGate("s", -1, 0);
+circuit.addGate("t", -1, 0);
+circuit.addGate("sdg", -1, 0);
+circuit.addGate("tdg", -1, 0);
+circuit.addGate("swap", -1, [0, 1]);
+circuit.addGate("srswap", -1, [0, 1]);
+circuit.addGate("cx", -1, [0, 1]);
+circuit.addGate("measure", -1, 0, {creg: {name: "c", bit: 0}});
+circuit.addMeasure(0, "c", 1);
+
+circuit.run();
+
+//console.log("");
+//console.log(circuit.exportPyquil());
+
+//console.log("");
+//console.log(circuit.exportQiskit());
+
+console.log("");
+console.log(circuit.exportCirq());

--- a/lib/quantum-circuit.js
+++ b/lib/quantum-circuit.js
@@ -349,6 +349,11 @@ var QuantumCircuit = function(numQubits) {
 					name: "u2",
 					params: ["phi", "lambda"],
 					array: "[[1/quil_sqrt(2),-quil_exp(1j*p_lambda)*1/quil_sqrt(2)],[quil_exp(1j*p_phi)*1/quil_sqrt(2),quil_exp(1j*p_lambda+1j*p_phi)*1/quil_sqrt(2)]]"
+				},
+				cirq: {
+					name: "u2",
+					params: ["phi", "lambda"],
+					array: "[[1/np.sqrt(2), -np.exp(1j*p_lambda)/np.sqrt(2)], [np.exp(1j*p_phi)/np.sqrt(2), np.exp(1j*p_lambda+1j*p_phi)/np.sqrt(2)]]"
 				}
 			}
 		},
@@ -374,6 +379,11 @@ var QuantumCircuit = function(numQubits) {
 					name: "u3",
 					params: ["theta", "phi", "lambda"],
 					array: "[[quil_cos(p_theta/2),-quil_exp(1j*p_lambda)*quil_sin(p_theta/2)],[quil_exp(1j*p_phi)*quil_sin(p_theta/2),quil_exp(1j*p_lambda+1j*p_phi)*quil_cos(p_theta/2)]]"
+				},
+				cirq: {
+					name: "u3",
+					params: ["theta", "phi", "lambda"],
+					array: "[[np.cos(p_theta/2), -np.exp(1j*p_lambda)*np.sin(p_theta/2)], [np.exp(1j*p_phi)*np.sin(p_theta/2), np.exp(1j*p_lambda+1j*p_phi)*np.cos(p_theta/2)]]"
 				}
 			}
 		},
@@ -3402,6 +3412,307 @@ QuantumCircuit.prototype.exportQuirk = function(decompose) {
 
 	return quirk;
 };
+
+
+QuantumCircuit.prototype.exportCirq = function(comment, decompose, exportAsGateName) {
+	var self = this;
+
+	var circuit = null;
+
+	// decompose
+	if(decompose) {
+		circuit = new QuantumCircuit();
+		circuit.load(this.save(true));
+	} else {
+		circuit = this;
+	}
+
+	var cirq = "";
+
+	// comment
+	if(comment) {
+		var comm = (comment || "").split("\n");
+		comm.map(function(cline) {
+			if(cline.length >= 1 && cline[0] != "#") {
+				cirq += "# ";
+			}
+			cirq += cline;
+			cirq += "\n";
+		});
+	}
+
+	var mathToStringHandler = function(node, options) {
+		if(node.isSymbolNode) {
+			if(node.name == "pi") {
+				return "np.pi";
+			}
+		}
+	};
+
+	var paramsToArg = function(gateName, gateParams) {
+		var argCount = 0;
+		if(gateParams) {
+			var gateDef = this.basicGates[gateName];
+			if(!gateDef) {
+				gateDef = this.customGates[gateName];
+			}
+
+			if(gateDef) {
+				var paramDef = gateDef.params || [];
+				var paramCount = paramDef.length;
+				if(paramCount) {
+					for(var p = 0; p < paramCount; p++) {
+						if(argCount > 0) {
+							cirq += ", ";
+						}
+						var paramName = paramDef[p];
+
+						// ---
+						// prepend 'np' to math constants
+						var node = math.parse(gateParams[paramName]);
+						cirq += node.toString({ handler: mathToStringHandler });
+						// ---
+
+						argCount++;
+					}
+				}
+			}
+		}
+	};
+
+	cirq += "import cirq\n";
+	cirq += "import numpy as np\n";
+	cirq += "\n";
+	if(!decompose) {
+		for(var customGateName in this.customGates) {
+			var customGate = this.customGates[customGateName];
+			var customCircuit = new QuantumCircuit();
+			customCircuit.load(customGate);
+			cirq += customCircuit.exportCirq("", true);
+		}
+	}
+
+	var defGates = "";
+	var usedGates = circuit.usedGates();
+	usedGates.map(function(usedGateName) {
+		var basicGate = circuit.basicGates[usedGateName];
+		if(basicGate) {
+			if(basicGate.exportInfo && basicGate.exportInfo.cirq) {
+				var cirqInfo = basicGate.exportInfo.cirq;
+				if(cirqInfo.array) {
+
+					// defgate
+
+					defGates += "def " + usedGateName + "(";
+					var paramList = "";
+					if(cirqInfo.params) {
+						paramList += ", [";
+						cirqInfo.params.map(function(paramName, paramIndex) {
+							if(paramIndex > 0) {
+								defGates += ", ";
+							}
+							defGates += "p_" + paramName;
+						});
+						paramList += "]";
+					}
+					defGates += "):\n";
+					defGates += "    return cirq.SingleQubitMatrixGate(np.array(" + cirqInfo.array + "))\n";
+					defGates += "\n";
+				}
+			}
+		}
+	});
+	cirq += defGates;
+
+	cirq += "q = [cirq.NamedQubit('q' + str(i)) for i in range(" + circuit.numQubits + ")]\n";
+	cirq += "\n";
+	cirq += "circuit = cirq.Circuit.from_ops(\n";
+
+	var numCols = circuit.numCols();
+	for(var column = 0; column < numCols; column++) {
+		for(var wire = 0; wire < this.numQubits; wire++) {
+			var gate = circuit.getGateAt(column, wire);
+			if(gate && gate.connector == 0) {
+				if(exportAsGateName) {
+					cirq += "  ";
+				}
+
+				var gateName = gate.name;
+				var gateParams = gate.options && gate.options.params ? gate.options.params : {};
+				switch(gateName) {
+					case "id": {
+						callerName = "cirq.Rz(0)";
+					}; break;
+
+					case "x": {
+						callerName = "cirq.X";
+					}; break;
+
+					case "y": {
+						callerName = "cirq.Y";
+					}; break;
+
+					case "z": {
+						callerName = "cirq.Z";
+					}; break;
+
+					case "h": {
+						callerName = "cirq.H";
+					}; break;
+
+					case "srn": {
+						callerName = "(cirq.X**(1/2))";
+					}; break;
+
+					case "r2": {
+						callerName = "cirq.Rz(np.pi / 2)";
+					}; break;
+
+					case "r4": {
+						callerName = "cirq.Rz(np.pi / 4)";
+					}; break;
+
+					case "r8": {
+						callerName = "cirq.Rz(np.pi / 8)";
+					}; break;
+
+					case "rx": {
+						callerName = "cirq.Rx";
+					}; break;
+
+					case "ry": {
+						callerName = "cirq.Ry";
+					}; break;
+
+					case "rz": {
+						callerName = "cirq.Rz";
+					}; break;
+
+					case "u1": {
+						callerName = "cirq.Rz";
+					}; break;
+
+					case "u2": {
+						callerName = "u2";
+					}; break;
+
+					case "u3": {
+						callerName = "u3";
+					}; break;
+
+					case "s": {
+						callerName = "cirq.S";
+					}; break;
+
+					case "t": {
+						callerName = "cirq.T";
+					}; break;
+
+					case "sdg": {
+						callerName = "cirq.Rz(-np.pi)";
+					}; break;
+
+					case "tdg": {
+						callerName = "cirq.Rz(-np.pi / 2)";
+					}; break;
+
+					case "swap": {
+						callerName = "cirq.SWAP";
+					}; break;
+
+					case "srswap": {
+						callerName = "(cirq.SWAP**(1/2))";
+					}; break;
+
+					case "cx": {
+						callerName = "cirq.CNOT";
+					}; break;
+
+					case "measure": {
+						callerName = "cirq.measure";
+					}; break;
+				}
+
+				var tmpParamCount = 0;
+				var paramString = "";
+
+				if(gateParams) {
+					var gateDef = this.basicGates[gateName];
+					if(!gateDef) {
+						gateDef = this.customGates[gateName];
+					}
+
+					if(gateDef) {
+						var paramDef = gateDef.params || [];
+						var paramCount = paramDef.length;
+						if(paramCount) {
+							for(var p = 0; p < paramCount; p++) {
+								if(tmpParamCount == 0) {
+									paramString += "(";
+								}
+								if(tmpParamCount > 0) {
+									paramString += ", ";
+								}
+								var paramName = paramDef[p];
+
+								// ---
+								// prepend 'np' to math constants
+								var node = math.parse(gateParams[paramName]);
+								paramString += node.toString({ handler: mathToStringHandler });
+								// ---
+
+								if(tmpParamCount == paramCount - 1) {
+									paramString += ")";
+								}
+								tmpParamCount++;
+							}
+						}
+					}
+				}
+				cirq += "    " + callerName + paramString + "(";
+
+				var argCount = 0;
+
+				for(var w = 0; w < gate.wires.length; w++) {
+					if(argCount > 0) {
+						cirq += ", ";
+					}
+					if(exportAsGateName) {
+						cirq += String.fromCharCode(97 + gate.wires[w]);
+					} else {
+						cirq += "q[" + gate.wires[w] + "]";
+					}
+					argCount++;
+				}
+
+				if(gateName == "measure" && gate.options && gate.options.creg) {
+					if(argCount > 0) {
+						cirq += ", key=";
+					}
+
+					cirq += "'" + gate.options.creg.name + gate.options.creg.bit + "'";
+					argCount++;
+				}
+
+				cirq += "),";
+
+				if(gate.options && gate.options.condition && gate.options.condition.creg) {
+					cirq += ".c_if(" + gate.options.condition.creg + ", " + gate.options.condition.value + "),";
+				}
+
+				cirq += "\n";
+			}
+		}
+	}
+
+	cirq += ")\n";
+	cirq += "\n";
+	cirq += "simulator = cirq.google.XmonSimulator()\n";
+	cirq += "result = simulator.run(circuit)\n";
+	cirq += "print(result)\n";
+
+	return cirq;
+}
 
 
 QuantumCircuit.prototype.exportSVG = function(embedded, options) {


### PR DESCRIPTION
I implemented the feature of "export to Cirq".
However, the manner of implementation may be different that this project intends.
Therefore, there is no problem even if this pull request is not accepted.

Run various_gates.js to check this feature.

```python
import cirq
import numpy as np

def u2(p_phi, p_lambda):
    return cirq.SingleQubitMatrixGate(np.array([[1/np.sqrt(2), -np.exp(1j*p_lambda)/np.sqrt(2)], [np.exp(1j*p_phi)/np.sqrt(2), np.exp(1j*p_lambda+1j*p_phi)/np.sqrt(2)]]))

def u3(p_theta, p_phi, p_lambda):
    return cirq.SingleQubitMatrixGate(np.array([[np.cos(p_theta/2), -np.exp(1j*p_lambda)*np.sin(p_theta/2)], [np.exp(1j*p_phi)*np.sin(p_theta/2), np.exp(1j*p_lambda+1j*p_phi)*np.cos(p_theta/2)]]))

q = [cirq.NamedQubit('q' + str(i)) for i in range(2)]

circuit = cirq.Circuit.from_ops(
    cirq.Rz(0)(q[0]),
    cirq.X(q[0]),
    cirq.Y(q[0]),
    cirq.Z(q[0]),
    cirq.H(q[0]),
    (cirq.X**(1/2))(q[0]),
    cirq.Rz(np.pi / 2)(q[0]),
    cirq.Rz(np.pi / 4)(q[0]),
    cirq.Rz(np.pi / 8)(q[0]),
    cirq.Rx(np.pi / 2)(q[0]),
    cirq.Ry(np.pi / 2)(q[0]),
    cirq.Rz(np.pi / 2)(q[0]),
    cirq.Rz(np.pi / 2)(q[0]),
    u2(np.pi / 2, np.pi / 4)(q[0]),
    u3(np.pi / 2, np.pi / 4, np.pi / 8)(q[0]),
    cirq.S(q[0]),
    cirq.T(q[0]),
    cirq.Rz(-np.pi)(q[0]),
    cirq.Rz(-np.pi / 2)(q[0]),
    cirq.SWAP(q[0], q[1]),
    (cirq.SWAP**(1/2))(q[0], q[1]),
    cirq.CNOT(q[0], q[1]),
    cirq.measure(q[0], key='c0'),
    cirq.measure(q[0], key='c1'),
)

simulator = cirq.google.XmonSimulator()
result = simulator.run(circuit)
print(result)
```